### PR TITLE
Improve TMDB fetch resilience and stabilize media page loading

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,51 @@
+import react from "eslint-plugin-react";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+
+export default [
+  {
+    ignores: ["dist/**", "proxy/**"],
+  },
+  {
+    files: ["**/*.{js,jsx}"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+      globals: {
+        window: "readonly",
+        document: "readonly",
+        navigator: "readonly",
+        console: "readonly",
+        fetch: "readonly",
+        URLSearchParams: "readonly",
+        setTimeout: "readonly",
+      },
+    },
+    settings: {
+      react: {
+        version: "detect",
+      },
+    },
+    plugins: {
+      react,
+      "react-hooks": reactHooks,
+      "react-refresh": reactRefresh,
+    },
+    rules: {
+      ...react.configs.recommended.rules,
+      ...reactHooks.configs.recommended.rules,
+      "no-unused-vars": "off",
+      "react/no-unknown-property": "off",
+      "react/display-name": "off",
+      "react/jsx-no-target-blank": "off",
+      "react/react-in-jsx-scope": "off",
+      "react/prop-types": "off",
+      "react-refresh/only-export-components": "off",
+    },
+  },
+];

--- a/src/components/media/Photos.jsx
+++ b/src/components/media/Photos.jsx
@@ -1,17 +1,17 @@
 const imgBaseURL = "https://movies-proxy.vercel.app/ipx/f_webp&s_400x600/tmdb/";
 
 const Photos = ({ item }) => {
-  console.log(item);
+  const backdrops = item?.images?.backdrops ?? [];
+  const posters = item?.images?.posters ?? [];
+
   return (
     <div className="flex flex-col px-4 py-8 gap-6 md:px-16">
       <div className="flex gap-2 items-baseline">
         <div className="text-2xl">Backdrops </div>
-        <div className="text-sm opacity-50">
-          {item?.images.backdrops.length} images
-        </div>
+        <div className="text-sm opacity-50">{backdrops.length} images</div>
       </div>
       <div className="grid grid-cols-[repeat(auto-fill,minmax(20rem,1fr))] gap-4">
-        {item?.images.backdrops.map((image, i) => (
+        {backdrops.map((image, i) => (
           <button
             key={i}
             className="relative w-full overflow-hidden aspect-video transition duration-300 hover:scale-[1.02] z-10"
@@ -28,12 +28,10 @@ const Photos = ({ item }) => {
       </div>
       <div className="flex gap-2 items-baseline">
         <div className="text-2xl">Posters </div>
-        <div className="text-sm opacity-50">
-          {item?.images.posters.length} images
-        </div>
+        <div className="text-sm opacity-50">{posters.length} images</div>
       </div>
       <div className="grid grid-cols-[repeat(auto-fill,minmax(10rem,1fr))] gap-4 lg:grid-cols-[repeat(auto-fill,minmax(15rem,1fr))]">
-        {item?.images.posters.map((image, i) => (
+        {posters.map((image, i) => (
           <button
             key={i}
             className="text-left block aspect-9/16 transition duration-300 hover:scale-[1.02] z-10"

--- a/src/hooks/useMediaData.jsx
+++ b/src/hooks/useMediaData.jsx
@@ -8,29 +8,26 @@ const useMediaData = (isRoot, pathname) => {
     ? [QUERY_LIST.movie[0], QUERY_LIST.tv[0]]
     : QUERY_LIST[type];
 
-  // Use React Query for media list
   const mediaQueries = useQueries({
     queries: queries.map((query) => ({
       queryKey: ["media", query.type, query.query],
       queryFn: () => listMedia(query.type, query.query, 1),
-      staleTime: 5 * 60 * 1000, // Consider data fresh for 5 minutes
-      cacheTime: 30 * 60 * 1000, // Keep in cache for 30 minutes
+      staleTime: 5 * 60 * 1000,
+      gcTime: 30 * 60 * 1000,
     })),
   });
 
   const media = mediaQueries.map((query) =>
-    query.data?.data?.results ? [query.data.data.results] : [],
+    query.data?.results ? [query.data.results] : [],
   );
 
-  // Use React Query for hero media
   const heroId = media[0]?.[0]?.[0]?.id;
   const { data: item } = useQuery({
     queryKey: ["hero", type, heroId],
     queryFn: () => getMedia(type, heroId),
     enabled: !!heroId,
     staleTime: 5 * 60 * 1000,
-    cacheTime: 30 * 60 * 1000,
-    select: (data) => data?.data,
+    gcTime: 30 * 60 * 1000,
   });
 
   return {

--- a/src/pages/[type]/category/[query].jsx
+++ b/src/pages/[type]/category/[query].jsx
@@ -21,21 +21,26 @@ const MediaQuery = () => {
     setLoading(true);
     try {
       const res = await listMedia(type, query, pageNum);
-      const data = await res.results;
+      const data = res?.results ?? [];
 
-      if (data?.length === 0) {
-        setHasMore(false); // No more data to fetch
+      if (data.length === 0) {
+        setHasMore(false);
       } else {
         setMedia((prevMedia) => [...prevMedia, ...data]);
       }
     } catch (error) {
-      console.log("Error occured fetching media", error);
+      console.error("Error occurred fetching media", error);
+      setHasMore(false);
     } finally {
-      setTimeout(() => {
-        setLoading(false);
-      }, 500);
+      setLoading(false);
     }
   };
+
+  useEffect(() => {
+    setPage(1);
+    setMedia([]);
+    setHasMore(true);
+  }, [query, type]);
 
   useEffect(() => {
     fetchMediaPages(page);
@@ -65,7 +70,7 @@ const MediaQuery = () => {
         scroller.removeEventListener("scroll", handleScroll);
       }
     };
-  }, [loading, hasMore, scrollerref]);
+  }, [loading, hasMore]);
 
   return (
     <AppScroller ref={scrollerref}>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -57,7 +57,7 @@ const MediaContent = ({ isRoot = false }) => {
 
   useEffect(() => {
     getMediaList();
-  }, [isRoot]);
+  }, [isRoot, pathname]);
 
   useEffect(() => {
     if (isTrailerOpen && modalRef.current) {

--- a/src/pages/person/index.jsx
+++ b/src/pages/person/index.jsx
@@ -7,17 +7,31 @@ const buildURL = (imagePath, size) =>
   `${imgBaseURL}/f_webp&s_${size}/tmdb/${imagePath}`;
 
 const Person = () => {
-  const params = useParams();
+  const { id } = useParams();
   const [person, setPerson] = useState(null);
 
   useEffect(() => {
+    let isMounted = true;
+
     const getPersonDetails = async () => {
-      const data = await getPerson(params.id);
-      setPerson(data);
-      console.log(data);
+      try {
+        const data = await getPerson(id);
+        if (isMounted) {
+          setPerson(data);
+        }
+      } catch (error) {
+        console.error("Error fetching person details", error);
+      }
     };
-    getPersonDetails();
-  }, [params]);
+
+    if (id) {
+      getPersonDetails();
+    }
+
+    return () => {
+      isMounted = false;
+    };
+  }, [id]);
 
   return (
     <div className="max-w-[1200px] w-full h-dvh mx-auto flex order-first lg:order-last">
@@ -32,7 +46,7 @@ const Person = () => {
               src={buildURL(person.profile_path, "400x600")}
               srcSet={`${buildURL(person.profile_path, "400x600")} 1x, ${buildURL(person.profile_path, "800x1200")} 2x`}
               alt={person?.name + "'s avatar"}
-              fetchpriority="low"
+              fetchPriority="low"
             />
           ) : (
             <div className="h-full flex items-center justify-center opacity-20">
@@ -45,7 +59,9 @@ const Person = () => {
         <div className="p-4">
           <h1 className="text-3xl mb-4">{person?.name}</h1>
           <div className="mb-2">
-            <strong className="opacity-70">{person?.known_for_department}</strong>
+            <strong className="opacity-70">
+              {person?.known_for_department}
+            </strong>
           </div>
           <div className="leading-relaxed opacity-80 whitespace-pre-line">
             {person?.biography || "Biography not available."}

--- a/src/services/tmdb.js
+++ b/src/services/tmdb.js
@@ -6,9 +6,10 @@ async function fetchTMDB(url, params = {}) {
     ...params,
   });
 
+  const requestUrl = `${TMDB_API_URL}/${url}?${searchParams}`;
+
   try {
-    const response = await fetch(`${TMDB_API_URL}/${url}?${searchParams}`);
-    console.log(`${TMDB_API_URL}/${url}?${searchParams}`);
+    const response = await fetch(requestUrl);
 
     if (!response.ok) {
       throw new Error(`HTTP Error!, status: ${response.status}`);
@@ -16,7 +17,9 @@ async function fetchTMDB(url, params = {}) {
 
     return await response.json();
   } catch (error) {
-    console.error("Fetch error", error);
+    throw new Error(`Failed to fetch TMDB resource: ${requestUrl}`, {
+      cause: error,
+    });
   }
 }
 
@@ -48,5 +51,5 @@ export async function getMoviesByQuery(query, page = 1) {
 }
 
 export async function getPerson(id) {
-  return await fetchTMDB(`person/${id}`);
+  return fetchTMDB(`person/${id}`);
 }


### PR DESCRIPTION
### Motivation
- The project’s linting stopped working with ESLint v9 and several runtime crashes and silent failures were observed when TMDB responses were missing expected fields. 
- Photo and person pages could throw when image arrays were absent or when a component updated state after unmount. 
- Category infinite-scroll and the homepage list loading didn’t reliably reset or react to route changes. 

### Description
- Add an ESLint flat config (`eslint.config.js`) wired for React and hooks so `npm run lint` works with ESLint v9 and repository rules/ignores are applied. 
- Harden TMDB calls in `src/services/tmdb.js` by removing noisy debug logging and rethrowing errors with the request URL as context instead of swallowing them. 
- Make the Photos component defensive by defaulting `backdrops`/`posters` to empty arrays before rendering to avoid crashes when those arrays are missing. 
- Improve person page data loading in `src/pages/person/index.jsx` by using `id` as the effect dependency, adding error handling and an isMounted guard, and fixing `fetchPriority` casing. 
- Stabilize category paging in `src/pages/[type]/category/[query].jsx` by resetting pagination on `query/type` changes, handling empty/error responses consistently, and removing an unnecessary loading delay. 
- Align `useMediaData` (`src/hooks/useMediaData.jsx`) with actual response shapes and React Query v5 options by reading `data.results` and using `gcTime` instead of `cacheTime`. 
- Ensure homepage media reloads on route changes by adding `pathname` to the effect dependencies in `src/pages/index.jsx`. 

### Testing
- Ran `npm run lint` and the project linter completed successfully (no blocking errors). 
- Ran `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985ef59dc5c832a979dcd009487d194)